### PR TITLE
Разбіў клас на дзве асобныя зручныя функцыі. Цяпер старая лацінка

### DIFF
--- a/src/latynkatar/__init__.py
+++ b/src/latynkatar/__init__.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License v3
 :copyright: (c) 2023, 2024 by Andrej Zacharevicz.
 """
 
-from .latynkatar import Cyr2Lat
+from .latynkatar import convert, convert_old
 
 
-__all__ = ["Cyr2Lat"]
+__all__ = ["convert", "convert_old"]

--- a/src/latynkatar/latynkatar.py
+++ b/src/latynkatar/latynkatar.py
@@ -100,11 +100,11 @@ def _miakkuja_zycznyja(
     return converted_letter
 
 
-def _convert(text: str, classic: bool = False, miakkasc: bool = True) -> str:
+def _convert(text: str, modern: bool = True, miakkasc: bool = True) -> str:
     converted_text = ""
     text_length = len(text)
     biahuczyja_pravily = (
-        KLASICZNYJA_PRAWILY_KANVERTACYJI if classic else PRAVILY_KANVERTACYJ
+        PRAVILY_KANVERTACYJ if modern else KLASICZNYJA_PRAWILY_KANVERTACYJI
     )
 
     for index, current_letter in enumerate(text):
@@ -148,11 +148,9 @@ def _convert(text: str, classic: bool = False, miakkasc: bool = True) -> str:
     return converted_text
 
 
-class Cyr2Lat:
-    @classmethod
-    def convert(cls, text: str, miakkasc: bool = True) -> str:
-        return _convert(text=text, classic=False, miakkasc=miakkasc)
+def convert(text: str, miakkasc: bool = True) -> str:
+    return _convert(text=text, modern=True, miakkasc=miakkasc)
 
-    @classmethod
-    def convert_classic(cls, text: str, miakkasc: bool = True) -> str:
-        return _convert(text=text, classic=True, miakkasc=miakkasc)
+
+def convert_old(text: str, miakkasc: bool = True) -> str:
+    return _convert(text=text, modern=False, miakkasc=miakkasc)

--- a/tests/test_halosnyja.py
+++ b/tests/test_halosnyja.py
@@ -1,13 +1,13 @@
 # Try to import from module, else import from the source code
 try:
-    from latynkatar import Cyr2Lat
+    import latynkatar
 except ModuleNotFoundError:
-    from src.latynkatar import Cyr2Lat
+    import src.latynkatar as latynkatar
 
 
 def test_ju():
-    assert Cyr2Lat.convert("ЮрліВец лЮбіЦь лІю п'ю") == "JurliViec lUbiĆ lIju pju"
+    assert latynkatar.convert("ЮрліВец лЮбіЦь лІю п'ю") == "JurliViec lUbiĆ lIju pju"
 
 
 def test_ja():
-    assert Cyr2Lat.convert("Яз'яваЗЯпазЬяВА") == "JazjavaZIapaźjaVA"
+    assert latynkatar.convert("Яз'яваЗЯпазЬяВА") == "JazjavaZIapaźjaVA"

--- a/tests/test_tekst.py
+++ b/tests/test_tekst.py
@@ -1,8 +1,8 @@
 # Try to import from module, else import from the source code
 try:
-    from latynkatar import Cyr2Lat
+    import latynkatar
 except ModuleNotFoundError:
-    from src.latynkatar import Cyr2Lat
+    import src.latynkatar as latynkatar
 
 from time import monotonic
 
@@ -108,24 +108,24 @@ with open("tests/data/novaja_ziamla.txt", "r") as novy_fail:
 
 
 def test_z_pamylki():
-    assert Cyr2Lat.convert(PRYKŁAD_PAMYŁKA) == UZOR_PAMYŁKA
+    assert latynkatar.convert(PRYKŁAD_PAMYŁKA) == UZOR_PAMYŁKA
 
 
 def test_z_pamylki_klasiczny():
-    assert Cyr2Lat.convert_classic(PRYKŁAD_PAMYŁKA) == UZOR_PAMYŁKA_KLASIČNY
+    assert latynkatar.convert_old(PRYKŁAD_PAMYŁKA) == UZOR_PAMYŁKA_KLASIČNY
 
 
 def test_bahdanovicz():
-    assert Cyr2Lat.convert(PRYKŁAD_BAHDANOVIČ) == UZOR_BAHDANOVIČ
+    assert latynkatar.convert(PRYKŁAD_BAHDANOVIČ) == UZOR_BAHDANOVIČ
 
 
 def test_bahdanovicz_klasiczny():
-    assert Cyr2Lat.convert_classic(PRYKŁAD_BAHDANOVIČ) == UZOR_BAHDANOVIČ_KLASICZNY
+    assert latynkatar.convert_old(PRYKŁAD_BAHDANOVIČ) == UZOR_BAHDANOVIČ_KLASICZNY
 
 
 def test_novaj_ziamloju():
     start = monotonic()
-    _ = Cyr2Lat.convert(NOVAJA_ZIAMLA)
+    _ = latynkatar.convert(NOVAJA_ZIAMLA)
     finish = monotonic()
 
     time_required = finish - start
@@ -137,7 +137,7 @@ def test_novaj_ziamloju():
 
 def test_novaj_ziamloju_klasicny():
     start = monotonic()
-    _ = Cyr2Lat.convert_classic(NOVAJA_ZIAMLA)
+    _ = latynkatar.convert_old(NOVAJA_ZIAMLA)
     finish = monotonic()
 
     time_required = finish - start

--- a/tests/test_zyćnyja.py
+++ b/tests/test_zyćnyja.py
@@ -1,60 +1,60 @@
 # Try to import from module, else import from the source code
 try:
-    from latynkatar import Cyr2Lat
+    import latynkatar
 except ModuleNotFoundError:
-    from src.latynkatar import Cyr2Lat
+    import src.latynkatar as latynkatar
 
 
 def test_l():
-    assert Cyr2Lat.convert("ЛаЭлЯЛуЛіЛюЛЁлЕлЬ лЛя") == "ŁaElAŁuLiLuLOlEl lLa"
+    assert latynkatar.convert("ЛаЭлЯЛуЛіЛюЛЁлЕлЬ лЛя") == "ŁaElAŁuLiLuLOlEl lLa"
 
 
 def test_ch():
-    assert Cyr2Lat.convert("ХаХу ХЫВАХххххх Хіх") == "ChaChu ChYVAChchchchchch Chich"
+    assert latynkatar.convert("ХаХу ХЫВАХххххх Хіх") == "ChaChu ChYVAChchchchchch Chich"
 
 
 def test_sz():
-    assert Cyr2Lat.convert_classic("ШашуШышшшшшшш") == "SzaszuSzyszszszszszszsz"
+    assert latynkatar.convert_old("ШашуШышшшшшшш") == "SzaszuSzyszszszszszszsz"
 
 
 def test_š():
-    assert Cyr2Lat.convert("ШашуШышшшшшшш") == "ŠašuŠyššššššš"
+    assert latynkatar.convert("ШашуШышшшшшшш") == "ŠašuŠyššššššš"
 
 
 def test_cz():
-    assert Cyr2Lat.convert_classic("чАЧыЧУ") == "czACzyCzU"
+    assert latynkatar.convert_old("чАЧыЧУ") == "czACzyCzU"
 
 
 def test_č():
-    assert Cyr2Lat.convert("чАЧыЧУ") == "čAČyČU"
+    assert latynkatar.convert("чАЧыЧУ") == "čAČyČU"
 
 
 def test_ż():
-    assert Cyr2Lat.convert_classic("жУрАвІнЫЖэЖЫ") == "żUrAwInYŻeŻY"
+    assert latynkatar.convert_old("жУрАвІнЫЖэЖЫ") == "żUrAwInYŻeŻY"
 
 
 def test_ž():
-    assert Cyr2Lat.convert("жУрАвІнЫЖэЖЫ") == "žUrAvInYŽeŽY"
+    assert latynkatar.convert("жУрАвІнЫЖэЖЫ") == "žUrAvInYŽeŽY"
 
 
 def test_w():
-    assert Cyr2Lat.convert_classic("войт і Ваявода") == "wojt i Wajawoda"
+    assert latynkatar.convert_old("войт і Ваявода") == "wojt i Wajawoda"
 
 
 def test_v():
-    assert Cyr2Lat.convert("войт і Ваявода") == "vojt i Vajavoda"
+    assert latynkatar.convert("войт і Ваявода") == "vojt i Vajavoda"
 
 
 def test_miakkaści():
     assert (
-        Cyr2Lat.convert("снег смех поспех святы Валянцін жаданні пустазелле")
+        latynkatar.convert("снег смех поспех святы Валянцін жаданні пустазелле")
         == "śnieh śmiech pośpiech śviaty Valancin žadańni pustazielle"
     )
 
 
 def test_biez_miakkaści():
     assert (
-        Cyr2Lat.convert(
+        latynkatar.convert(
             "снег смех поспех святы Валянцін жаданні пустазелле", miakkasc=False
         )
         == "snieh smiech pospiech sviaty Valancin žadanni pustazielle"


### PR DESCRIPTION
("польская") проста старая, а не "класічная".