### PR TITLE
Прадухіліў змены фармата кода на CI, толькі праверка. Пераглядзеў настройкі.

### DIFF
--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Install dependencies
       run: uv sync --dev
     - name: Test with the whole power of nox
-      run: uv run nox -t tests
+      run: uv run nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,7 +62,7 @@ def isort_check(session):
 
 @nox.session(tags=["lint"])
 def ruff(session):
-    """Фарматаванне і статычныя тэсты ruff."""
+    """Cтатычныя тэсты ruff."""
     session.install("ruff")
     session.run("ruff", "check", "tests/", "src/", "noxfile.py")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,6 @@ import toml
 
 SHOULD_BE_REPLACED = {
     "isort": "isort_check",
-    "ruff": "ruff_check",
     "black": "black_check",
 }
 
@@ -20,9 +19,9 @@ def replace_by_checks(session_name):
 
 
 nox.options.sessions = [
+    "black",
     "isort",
     "ruff",
-    "black",
     "flake8",
     "pylint",
     "mypy",
@@ -31,6 +30,20 @@ nox.options.sessions = [
 
 if os.getenv("CI"):
     nox.options.sessions = list(map(replace_by_checks, nox.options.sessions))
+
+
+@nox.session(tags=["lint"])
+def black(session):
+    """Фарматуе код па правілах black."""
+    session.install("black")
+    session.run("black", "tests", "src", "noxfile.py")
+
+
+@nox.session
+def black_check(session):
+    """паказвае што ў кодзе змяніў бы black."""
+    session.install("black")
+    session.run("black", "--diff", "tests/", "src/", "noxfile.py")
 
 
 @nox.session(tags=["lint"])
@@ -51,30 +64,7 @@ def isort_check(session):
 def ruff(session):
     """Фарматаванне і статычныя тэсты ruff."""
     session.install("ruff")
-    session.run("ruff", "format", "tests/", "src/", "noxfile.py")
     session.run("ruff", "check", "tests/", "src/", "noxfile.py")
-
-
-@nox.session
-def ruff_check(session):
-    """Статычныя тэсты і праверка фарматавання ruff."""
-    session.install("ruff")
-    session.run("ruff", "format", "--diff", "tests/", "src/", "noxfile.py")
-    session.run("ruff", "check", "tests/", "src/", "noxfile.py")
-
-
-@nox.session
-def black_check(session):
-    """паказвае што ў кодзе змяніў бы black."""
-    session.install("black")
-    session.run("black", "--diff", "tests/", "src/", "noxfile.py")
-
-
-@nox.session(tags=["lint"])
-def black(session):
-    """Фарматуе код па правілах black."""
-    session.install("black")
-    session.run("black", "tests", "src", "noxfile.py")
 
 
 @nox.session(tags=["lint"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,14 @@ max-line-length = 120
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = 120
 
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 120
+[tool.ruff.lint]
+select = ["E", "F", "B"]
+
 [dependency-groups]
 dev = [
     "nox>=2025.2.9",

--- a/src/latynkatar/latynkatar.py
+++ b/src/latynkatar/latynkatar.py
@@ -18,14 +18,10 @@ You should have received a copy of the GNU Lesser General Public License v3
 :copyright: (c) 2023, 2024 by Andrej Zacharevicz.
 """
 
-from .variables import (
-    HALOSNYJA,
-    JOTAWANYJA_LITARY,
-    KLASICZNYJA_PRAWILY_KANVERTACYJI,
-    MOHUC_PAZNACZACCA_JAK_MIAKKIJA,
-    PRAVILY_KANVERTACYJ,
-    ZYCZNYJA_Z_TRANZITAM,
-)
+from .variables import (HALOSNYJA, JOTAWANYJA_LITARY,
+                        KLASICZNYJA_PRAWILY_KANVERTACYJI,
+                        MOHUC_PAZNACZACCA_JAK_MIAKKIJA, PRAVILY_KANVERTACYJ,
+                        ZYCZNYJA_Z_TRANZITAM)
 
 
 def _ci_patrabuje_adlustravannia_tranzityunaj_miakkasci(

--- a/src/latynkatar/latynkatar.py
+++ b/src/latynkatar/latynkatar.py
@@ -18,10 +18,14 @@ You should have received a copy of the GNU Lesser General Public License v3
 :copyright: (c) 2023, 2024 by Andrej Zacharevicz.
 """
 
-from .variables import (HALOSNYJA, JOTAWANYJA_LITARY,
-                        KLASICZNYJA_PRAWILY_KANVERTACYJI,
-                        MOHUC_PAZNACZACCA_JAK_MIAKKIJA, PRAVILY_KANVERTACYJ,
-                        ZYCZNYJA_Z_TRANZITAM)
+from .variables import (
+    HALOSNYJA,
+    JOTAWANYJA_LITARY,
+    KLASICZNYJA_PRAWILY_KANVERTACYJI,
+    MOHUC_PAZNACZACCA_JAK_MIAKKIJA,
+    PRAVILY_KANVERTACYJ,
+    ZYCZNYJA_Z_TRANZITAM,
+)
 
 
 def _ci_patrabuje_adlustravannia_tranzityunaj_miakkasci(

--- a/tests/test_tekst.py
+++ b/tests/test_tekst.py
@@ -3,12 +3,13 @@
 # pylint: disable=non-ascii-name
 
 # Try to import from module, else import from the source code
+from time import monotonic
+
 try:
     import latynkatar
 except ModuleNotFoundError:
     from src import latynkatar
 
-from time import monotonic
 
 # Узор узяты з часопіса PAMYŁKA:
 # https://github.com/PAMYLKA-ZIN/pamylka-number-3/tree/main/PAMYLKA_ZIN_3_FOR_SHARING


### PR DESCRIPTION
## Апісанне

* Прадухіліў запуск фармату на `CI`. Толькі кантроль і праверка, паколькі змены ў кодзе тут не захоўваюцца.
* Прыбраў фарматар `ruff`. Ён не дадаваў шмат, але ствараў шэраг праблем у сумяшчальнасці.
* Настроіў `isort` каб ужываўся стыль `black`. Так можна будзе ўжываць абедзве прылады і не мець канфліктаў.

## Праверкі

`nox` лакальна і на Github

## Кантрольны спіс

*Выдаліце непатрэбныя пункты, усё што тычыцца вашага PR мусіць быць зроблена і адзначана.*

- [X] Загаловак PR, які максімальна коратка і сцісла апісвае сутнасць зменаў.
- [X] Усе складаныя і неадназначныя месцы ў кодзе маюць зразумелыя каментары
- [ ] PR мае пазнаку (tag), якая паказвае сутнасць зменаў
